### PR TITLE
締め切り日の設定とエラーメッセージ名の修正

### DIFF
--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Application model for Cake.
  *
@@ -32,17 +33,22 @@ App::uses('Model', 'Model');
  * @package       app.Model
  */
 class AppModel extends Model {
+	
 	/**
-	 * æ—¥ä»˜ã‚’æ¯”è¼ƒã™ã‚‹ãƒãƒªãƒ‡ãƒ¼ã‚·ãƒ§ãƒ³ãƒ«ãƒ¼ãƒ«.
-	 * ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã§ã¯ã€ç¾åœ¨ã®æ—¥ä»˜ã¨å¯¾è±¡ã®æ—¥ä»˜ã‚’æ¯”è¼ƒæ¼”ç®—å­ã®é€šã‚Šã«æ¯”è¼ƒã™ã‚‹.
-	 * ç¾åœ¨ã®æ—¥ä»˜ã¨ã®å·®åˆ†ãŒã‚ã‚‹å ´åˆã€ãã®åˆ†ã ã‘ãšã‚‰ã—ãŸæ—¥ä»˜ã¨å¯¾è±¡ã®æ—¥ä»˜ã‚’æ¯”è¼ƒã™ã‚‹.
-	 * æ¯”è¼ƒæ¼”ç®—å­ã¯ã€Validation::comparisonã¨åŒã˜ã‚‚ã®ãŒä½¿ãˆã‚‹.
-	 * ç¾åœ¨ã®æ—¥ä»˜ã¨ã®å·®åˆ†ã¯ã€strtotime()ã§timestampã§å¤‰æ›å¯èƒ½ãªæ–‡å­—åˆ—.
-	 * @param string $check1 æ¯”è¼ƒå¯¾è±¡ã®æ—¥ä»˜
-	 * @param string $operator æ¯”è¼ƒæ¼”ç®—å­
-	 * @param string $timestamp ç¾åœ¨ã®æ—¥ä»˜ã¨ã®å·®åˆ†
+	 * “ú•t‚ð”äŠr‚·‚éƒoƒŠƒf[ƒVƒ‡ƒ“ƒ‹[ƒ‹.
+	 * ƒfƒtƒHƒ‹ƒg‚Å‚ÍAŒ»Ý‚Ì“ú•t‚Æ‘ÎÛ‚Ì“ú•t‚ð”äŠr‰‰ŽZŽq‚Ì’Ê‚è‚É”äŠr‚·‚é.
+	 * Œ»Ý‚Ì“ú•t‚Æ‚Ì·•ª‚ª‚ ‚éê‡A‚»‚Ì•ª‚¾‚¯‚¸‚ç‚µ‚½“ú•t‚Æ‘ÎÛ‚Ì“ú•t‚ð”äŠr‚·‚é.
+	 * ”äŠr‰‰ŽZŽq‚ÍAValidation::comparison‚Æ“¯‚¶‚à‚Ì‚ªŽg‚¦‚é.
+	 * Œ»Ý‚Ì“ú•t‚Æ‚Ì·•ª‚ÍAstrtotime()‚Åtimestamp‚Å•ÏŠ·‰Â”\‚È•¶Žš—ñ.
+	 * @param string $check1 ”äŠr‘ÎÛ‚Ì“ú•t
+	 * @param string $operator ”äŠr‰‰ŽZŽq
+	 * @param string $timestamp Œ»Ý‚Ì“ú•t‚Æ‚Ì·•ª
 	 */
-	function comparisonDate($active_time, $operator, $timestamp = null) {//é–‹å‚¬æ—¥ãŒç¾åœ¨æ—¥ã‚’è¶…ãˆã¦ã„ã‚‹ã‹
+	
+
+	
+	
+	function comparisonDate($active_time, $operator, $timestamp = null) {//ŠJÃ“ú‚ªŒ»Ý“ú‚ð’´‚¦‚Ä‚¢‚é‚©
 		$active_time = is_array($active_time) ? array_shift($active_time) : $active_time;
 		$active_time = date("Y/m/d H:i:s", strtotime($active_time));
 		$now_time = !empty($timestamp) ? date("Y/m/d H:i:s") : $date("Y/m/d H:i:s", strtotime($timestamp));
@@ -94,41 +100,42 @@ class AppModel extends Model {
 		return false;
 	}
 	
-	function comparisonDate2($recruit_time, $operator, $timestamp = null) {//é–‹å‚¬æ—¥ã‚’ç· åˆ‡æ—¥ã‚’è¶…ãˆã¡ã‚ƒã„ã‘ãªã„
+function comparisonDate2($recruit_time, $operator, $timestamp = null) {//ŠJÃ“ú‚ð’÷Ø“ú‚ð’´‚¦‚¿‚á‚¢‚¯‚È‚¢
 		$recruit_time = is_array($recruit_time) ? array_shift($recruit_time) : $recruit_time;
 		$recruit_time = date("Y/m/d H:i:s", strtotime($recruit_time));
 		global $mark;
-		$active_time =  $mark;//markã¯é–‹å‚¬æ—¥ã®æ—¥ä»˜
+		$active_time =  $mark;//mark‚ÍŠJÃ“ú‚Ì“ú•t
+		$now_time = !empty($timestamp) ? date("Y/m/d H:i:s") : $date("Y/m/d H:i:s", strtotime($timestamp));
 		//print_r($recruit_time.$active_time);
 		$operator = str_replace(array(' ', "\t", "\n", "\r", "\0", "\x0B"), '', strtolower($operator));
 		switch ($operator) {
 			case 'isgreater':
 			case '>':
-				if ($active_time > $recruit_time) {
+				if ($active_time > $recruit_time&&$recruit_time>$now_time) {
 					return true;
 				}
 				break;
 			case 'isless':
 			case '<':
-				if ($active_time < $recruit_time) {
+				if ($active_time < $recruit_time&&$recruit_time>$now_time) {
 					return true;
 				}
 				break;
 			case 'greaterorequal':
 			case '>=':
-				if ($active_time >= $recruit_time) {
+				if ($active_time >= $recruit_time&&$recruit_time>$now_time) {
 					return true;
 				}
 				break;
 			case 'lessorequal':
 			case '<=':
-				if ($active_time <= $recruit_time) {
+				if ($active_time <= $recruit_time&&$recruit_time>$now_time) {
 					return true;
 				}
 				break;
 			case 'equalto':
 			case '==':
-				if ($active_time == $recruit_time) {
+				if ($active_time == $recruit_time&&$recruit_time>$now_time) {
 					return true;
 				}
 				break;
@@ -145,5 +152,4 @@ class AppModel extends Model {
 		}		
 		return false;
 	}
-	
 }

--- a/app/Model/Project.php
+++ b/app/Model/Project.php
@@ -32,7 +32,13 @@ class Project extends AppModel {
 				//'last' => false, // Stop validation after this rule
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
 			),
+		/*	'isUnique'=>array(
+			'rule'=>array('isUnique'),
+			//'message'=>'その企画はすでに登録されています。',
+		   // 'on'=>'create'
+	     	),*/
 		),
+		
 		'active_date' => array(
 			'notempty' => array(
 				'rule' => array('notempty'),
@@ -43,8 +49,8 @@ class Project extends AppModel {
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
 			),
 			'date' => array(
-					'rule' => array('comparisonDate', 'isgreater'),
-					'message' => '明日以降の日付を入力してください',
+					'rule' => array('comparisonDate', 'greaterorequal'),
+					'message' => '今以降の日付を入力してください',
 					//'allowEmpty' => false,
 					//'required' => false,
 					//'last' => false, // Stop validation after this rule
@@ -60,9 +66,13 @@ class Project extends AppModel {
 				//'last' => false, // Stop validation after this rule
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
 			),
+		
+	
 			'date' => array(
 					'rule' => array('comparisonDate2', 'greaterorequal'),
-					'message' => '明日以降の日付を入力してください',
+			
+			                 
+					'message' => '今以降かつ開催日以前の日付を入力してください',
 					//'allowEmpty' => false,
 					//'required' => false,
 					//'last' => false, // Stop validation after this rule


### PR DESCRIPTION
AppModel.phpでfunction
comparisonDate2内で、締め切り日がか現在より後になるように、$now_timeを取得し、if文に&&$recruit_time>$
now_timeを追加。

Project.phpでバリデーション'active_date’（開催日）と’recrouit_date’（締め切り日）のフィールド'date'
のエラーメッセージを修正。
それぞれ、今以降の日付・・・と今以降かつ開催日以前・・・に変更。
